### PR TITLE
Broken Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
           <h3>
           <a id="about-the-project" class="anchor" href="#about-the-project" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>About the project</h3>
 
-          <p>The project was started in 2016 as a <a href="bachelor_thesis_upd89.pdf">bachelor thesis</a> (German) at the <a href="http://www. hsr.ch">HSR University of Applied Sciences</a> Rapperswil, Switzerland.</p>
+          <p>The project was started in 2016 as a <a href="bachelor_thesis_upd89.pdf">bachelor thesis</a> (German) at the <a href="http://www.hsr.ch">HSR University of Applied Sciences</a> Rapperswil, Switzerland.</p>
       </section>
     </div>
 


### PR DESCRIPTION
Typo im Link zur HSR - Leerzeichen zwischen "www." und "hsr.ch" entfernt.